### PR TITLE
Fix: savefig should be called before show to avoid blank output images

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -47,8 +47,9 @@ def visualize_bounding_boxes(image, label, width, height, name):
     plt.axis("off")
     plt.title(f"Bounding Box: {category}")
     plt.tight_layout()
-    plt.show()
     plt.savefig(name)
+    plt.show()
+    plt.close()
 
 
 def train_collate_function(batch_of_samples, processor, dtype, transform=None):


### PR DESCRIPTION
When running `predict.py` in `utils.py` the `plt.show()` inside `visualize_bounding_boxes()` renders and clears the current figure, which can result in saved images being blank or missing the drawn annotations.
