### PR TITLE
combined emd_token and attn training in single stage, added flash_attn_2 argument in training script

### DIFF
--- a/config.py
+++ b/config.py
@@ -13,8 +13,8 @@ class Configuration:
 
     device: str = "cuda" if torch.cuda.is_available() else "cpu"
     dtype: torch.dtype = "auto" # Change to torch.bfloat16 for "google/gemma-3-4b-pt"
+    attn_implementation = "eager"  # flash_attention_2
 
     batch_size: int = 4 # 8 for "google/gemma-3-4b-pt"
     learning_rate: float = 2e-05
-    epochs = 2
-
+    epochs = 10


### PR DESCRIPTION
### 🚀 Summary

Fixes: https://github.com/ariG23498/gemma3-object-detection/issues/37
Addresses: https://github.com/ariG23498/gemma3-object-detection/issues/39


This PR combines the training of **emb_token** and **attn layers** into a single stage, rather than training them separately in two stages.

The original approach involved first training the **embed_tokens** layer, freezing it, and then training the **attn layers** in a second stage. However, this two-stage method doesn't yield satisfactory results, see the results below.

Previously:

```python
run_training_phase(model, processor, cfg, train_dataloader, train_keys=["embed_tokens"], phase_name="embed_only")
# embed_tokens learned

run_training_phase(model, processor, cfg, train_dataloader, train_keys=["embed_tokens", "attn"], phase_name="embed_attn")
# embed_tokens updated/disrupted
``` 

Now: 

```python
# embed_tokens and attn in single stage
run_training_phase(model, processor, cfg, train_dataloader, train_keys=["embed_tokens", "attn"], phase_name="embed_attn_embed_tokens")
```

---

### 896 <locxxxx> tokens instead of 1024 :question: 
My assumption was that matching the location tokens with image size would yield better results, but that's not true. See below in **Observations**. I have opened a separate issue here: https://github.com/ariG23498/gemma3-object-detection/issues/39, which I will close with appropriate comments. 

---

##  Why not embed_tokens training followed by attn training in two stages :question: 

As experimented, please find below the results for two-stage and one-stage training. 


### 📊 Results

<table>
  <tr>
    <th>Two stage(Previously) 1024 loc tokens</th>
    <th>One stage(Now) 1024 loc tokens</th>
    <th>One stage <br> 896 loc tokens instead of 1024 <br><span style='font-size:12px'>(addresses issue: <a href="https://github.com/ariG23498/gemma3-object-detection/issues/39">#39</a>)</span></th>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/2768b848-fcd9-4d56-8cce-5979c34d00d5" width="350"></td>
    <td><img src="https://github.com/user-attachments/assets/e6d77e85-9928-4c53-880b-dfdf0fd231d5" width="350"></td>
    <td><img src="https://github.com/user-attachments/assets/b8993622-608c-49af-9590-ec8111f447a5" width="350"></td>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/0591913e-f1ad-464c-bf79-7a114ad79074" width="350"></td>
    <td><img src="https://github.com/user-attachments/assets/15a62c90-d469-4031-86fb-e19715343bf2" width="350"></td>
    <td><img src="https://github.com/user-attachments/assets/b905f015-04c4-4cae-a3ee-1f85fa3c363d" width="350"></td>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/e4c00ff9-7ff8-40eb-aa7c-d58c9d0b6399" width="350"></td>
    <td><img src="https://github.com/user-attachments/assets/3351ab77-ce68-4b8e-a717-56e9dee01b65" width="350"></td>
    <td><img src="https://github.com/user-attachments/assets/e3d65d9c-830c-4789-a074-da0223340536" width="350"></td>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/a91f3005-d491-498e-af7d-ebd5c0f8196b" width="350"></td>
    <td><img src="https://github.com/user-attachments/assets/d00d035d-0d0e-4600-a134-5ad3ee31d6f0" width="350"></td>
    <td><img src="https://github.com/user-attachments/assets/2da1af69-7292-4b71-b41f-77f14e569d71" width="350"></td>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/ff6ead31-b5c3-4fd6-a1db-0c905d67b53e" width="350"></td>
    <td><img src="https://github.com/user-attachments/assets/7fc14ff6-9c91-4264-9914-07cd7def8ac1" width="350"></td>
    <td><img src="https://github.com/user-attachments/assets/c06a8316-9da4-4238-bc92-d44937dbdb51" width="350"></td>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/562112b7-413f-43dd-8667-e1df02a1e48d" width="350"></td>
    <td><img src="https://github.com/user-attachments/assets/4a335e50-7b7a-41fc-9ab1-9e6e4a25197d" width="350"></td>
    <td><img src="https://github.com/user-attachments/assets/77c59e01-040a-48c3-a13e-9d260c11bc00" width="350"></td>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/d710a0fb-b265-4a2e-a133-400c3b20bccc" width="350"></td>
    <td><img src="https://github.com/user-attachments/assets/59ed7da7-5383-4d5a-b1d4-af93cb2b1599" width="350"></td>
    <td><img src="https://github.com/user-attachments/assets/09c74efd-3495-48fe-afef-0a20a07f53d3" width="350"></td>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/2566cd04-2651-467a-8492-b4599083116d" width="350"></td>
    <td><img src="https://github.com/user-attachments/assets/397c528b-e9d4-4002-8ee0-fdee0753f2e5" width="350"></td>
    <td><img src="https://github.com/user-attachments/assets/c198bdad-aa95-40da-8376-c7abfecd54dd" width="350"></td>
  </tr>
</table>


### 🤔 Observations

- Single-stage training consistently yields better results, as demonstrated above. This is a positive outcome since training in a single stage reduces the overall training effort compared to the two stage training.

- Longer training durations are beneficial: Models trained for 10 epochs outperform those trained for only 2 epochs, where performance remains poor.

- Using 896 bins (location tokens) i.e., matching the input size, did not lead to improved results, contrary to my initial assumption (see [this issue](https://github.com/ariG23498/gemma3-object-detection/issues/39)). This finding suggests that matching the the number of tokens may not enhance performance, although it could be worth exploring even higher token counts in future experiments.


### :bug: Issues

For saving the models, I faced an issue with safe serialization of tensors, so the current models are saved using the following code. check this issue: https://github.com/huggingface/transformers/issues/27613#issuecomment-1848645557

```python
model.push_to_hub(cfg.checkpoint_id, safe_serialization=False)
processor.push_to_hub(cfg.checkpoint_id, safe_serialization=False)
```

### Loss graph

![image](https://github.com/user-attachments/assets/343f1ea1-9679-466b-87fc-c8bbdfa713e1)

- I think we should employ a learning rate scheduler here: Warmup for first few steps and then slowly cool down. 


### :smile: Checkpoints

- [ajaymin28/gemma-3-4b-pt-obj-det-loc-tok-1024-single-stage](https://huggingface.co/ajaymin28/gemma-3-4b-pt-obj-det-loc-tok-1024-single-stage)
- [ajaymin28/gemma-3-4b-pt-obj-det-loc-tok-1024-two-stage](https://huggingface.co/ajaymin28/gemma-3-4b-pt-obj-det-loc-tok-1024-two-stage)
- [ajaymin28/gemma-3-4b-pt-obj-det-loc-tok-896-single-stage](https://huggingface.co/ajaymin28/gemma-3-4b-pt-obj-det-loc-tok-896-single-stage)

### :dart: Future work

I think it's a promising result so far, but I believe there are a few areas that could further improve performance:

- We should consider which additional components to fine-tune beyond just **emb_tokens** and **attn**. I have opened an issue to discuss this in detail: https://github.com/ariG23498/gemma3-object-detection/issues/41

- ~~We may need to switch to a chat template, or at least verify that user and assistant messages are in the correct order. Please refer to this issue for more information: https://github.com/ariG23498/gemma3-object-detection/issues/40~~ Chat templates are applicable when we use instruction-tuned models(it), not pretrained(pt).


Let me know if you have any comments 😄 