### PR TITLE
Add cross validation loss calculation to training script

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 torch
 transformers
 accelerate
-datasets==3.6.0
+datasets
 matplotlib
 huggingface_hub[hf_xet]
 bitsandbytes

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 torch
 transformers
 accelerate
-datasets
+datasets==3.6.0
 matplotlib
 huggingface_hub[hf_xet]
 bitsandbytes

--- a/train.py
+++ b/train.py
@@ -33,9 +33,9 @@ def get_augmentations(cfg):
 
 
 
-def get_dataloader(processor, cfg):
-    logger.info("Fetching the dataset")
-    train_dataset = load_dataset(cfg.dataset_id, split="train")
+def get_dataloader(processor, cfg, split="train"):
+    logger.info(f"Fetching the {split} dataset")
+    train_dataset = load_dataset(cfg.dataset_id, split=split)
     train_collate_fn = partial(
         train_collate_function, processor=processor, device=cfg.device, transform=get_augmentations(cfg)
     )
@@ -45,12 +45,27 @@ def get_dataloader(processor, cfg):
         train_dataset,
         batch_size=cfg.batch_size,
         collate_fn=train_collate_fn,
-        shuffle=True,
+        shuffle=(split == "train"),
     )
     return train_dataloader
 
+# cross-validation
+@torch.no_grad()
+def evaluate_model(model, val_dataloader, device):
+    model.eval()
+    total_loss = 0
+    total_count = 0
+    for batch in val_dataloader:
+        batch = batch.to(device)
+        outputs = model(**batch)
+        loss = outputs.loss
+        total_loss += loss.item() * batch["input_ids"].size(0)
+        total_count += batch["input_ids"].size(0)
+    avg_loss = total_loss / total_count if total_count > 0 else 0
+    model.train()
+    return avg_loss
 
-def train_model(model, optimizer, cfg, train_dataloader):
+def train_model(model, optimizer, cfg, train_dataloader, val_dataloader=None):
     logger.info("Start training")
     global_step = 0
     for epoch in range(cfg.epochs):
@@ -65,6 +80,10 @@ def train_model(model, optimizer, cfg, train_dataloader):
             optimizer.step()
             optimizer.zero_grad()
             global_step += 1
+        if val_dataloader is not None:
+            val_loss = evaluate_model(model, val_dataloader, cfg.device)
+            logger.info(f"Epoch: {epoch} Validation Loss: {val_loss:.4f}")
+            wandb.log({"val/loss": val_loss, "epoch": epoch}, step=global_step)
     return model
 
 def set_trainable_params(model, keywords):
@@ -72,7 +91,7 @@ def set_trainable_params(model, keywords):
         param.requires_grad = any(k in name for k in keywords)
 
 
-def run_training_phase(model, processor, cfg, train_dataloader, train_keys, phase_name="phase"):
+def run_training_phase(model, processor, cfg, train_dataloader, train_keys, phase_name="phase", val_dataloader=None):
     set_trainable_params(model, train_keys)
     model.train()
     model.to(cfg.device)
@@ -86,7 +105,7 @@ def run_training_phase(model, processor, cfg, train_dataloader, train_keys, phas
         config=vars(cfg),
     )
 
-    train_model(model, optimizer, cfg, train_dataloader)
+    train_model(model, optimizer, cfg, train_dataloader, val_dataloader)
     wandb.finish()
 
 if __name__ == "__main__":
@@ -117,7 +136,8 @@ if __name__ == "__main__":
         logger.info("Adding location tokens to the tokenizer")
         processor = get_processor_with_new_tokens(processor)
 
-    train_dataloader = get_dataloader(processor=processor, cfg=cfg)
+    train_dataloader = get_dataloader(processor=processor, cfg=cfg, split="train")
+    val_dataloader = get_dataloader(processor=processor, cfg=cfg, split="validation")
 
     logger.info("Loading model")
     if "SmolVLM" in cfg.model_id:
@@ -129,10 +149,10 @@ if __name__ == "__main__":
         model = get_model_with_resize_token_embeddings(model, processor)
 
         logger.info("Single-stage: Fine-tuning embed_tokens + attn")
-        run_training_phase(model, processor, cfg, train_dataloader, train_keys=["embed_tokens", "attn"], phase_name="embed_attn_embed_tokens")
+        run_training_phase(model, processor, cfg, train_dataloader, train_keys=["embed_tokens", "attn"], phase_name="embed_attn_embed_tokens", val_dataloader=val_dataloader)
     else:
         logger.info("Single-stage: Fine-tuning attn only")
-        run_training_phase(model, processor, cfg, train_dataloader, train_keys=["attn"], phase_name="attn_only")
+        run_training_phase(model, processor, cfg, train_dataloader, train_keys=["attn"], phase_name="attn_only", val_dataloader=val_dataloader)
 
     model.push_to_hub(cfg.checkpoint_id)
     processor.push_to_hub(cfg.checkpoint_id)

--- a/train.py
+++ b/train.py
@@ -137,7 +137,11 @@ if __name__ == "__main__":
         processor = get_processor_with_new_tokens(processor)
 
     train_dataloader = get_dataloader(processor=processor, cfg=cfg, split="train")
-    val_dataloader = get_dataloader(processor=processor, cfg=cfg, split="validation")
+    try:
+        val_dataloader = get_dataloader(processor=processor, cfg=cfg, split="validation")
+    except ValueError:
+        logger.warning("No validation split found in the dataset. Validation will be skipped.")
+        val_dataloader = None
 
     logger.info("Loading model")
     if "SmolVLM" in cfg.model_id:


### PR DESCRIPTION
This PR enables the calculation of **cross validation loss**. It is added to `train.py`. 

For now the cross validation loss is calculated **after each epoch**. If you'd like to make it calculate every 5 / 10 / .. epochs, I can add an `if` condition before the loggers.

p.s. If there's no validation split in the dataset, the cross validation part will be skipped.