### PR TITLE
Add push_to_hub: safe_serialization=False

### DIFF
--- a/train.py
+++ b/train.py
@@ -134,7 +134,7 @@ if __name__ == "__main__":
         logger.info("Single-stage: Fine-tuning attn only")
         run_training_phase(model, processor, cfg, train_dataloader, train_keys=["attn"], phase_name="attn_only")
 
-    model.push_to_hub(cfg.checkpoint_id)
-    processor.push_to_hub(cfg.checkpoint_id)
+    model.push_to_hub(cfg.checkpoint_id, safe_serialization=False)
+    processor.push_to_hub(cfg.checkpoint_id, safe_serialization=False)
 
     logger.info("Train finished")


### PR DESCRIPTION
In terms of saving the models, I have faced the same issue with safe serialization of tensors, as mentioned in [#42 ](https://github.com/ariG23498/gemma3-object-detection/pull/42)

I also suggest changing to this:
```
model.push_to_hub(cfg.checkpoint_id, safe_serialization=False)
processor.push_to_hub(cfg.checkpoint_id, safe_serialization=False)
```